### PR TITLE
Fixed REACT homepage link

### DIFF
--- a/docfx_project/toc.yml
+++ b/docfx_project/toc.yml
@@ -11,8 +11,7 @@
     href: pro/reports/
     homepage: pro/reports/index.md
 - name: REACT 
-  href: /react/help/
-  homepage: react/index.md
+  href: /react/
   items:
   - name: Quick Start
     href: /react/help/quick-start.html


### PR DESCRIPTION
The REACT homepage link was misconfigured in the toolbar and the homepage. Fixed.