### PR TITLE
Added redirects for existing docs urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ FROM nginx:1.17.8-alpine as host
 
 WORKDIR /site
 
+COPY default.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /build/source/docfx_project/_site /usr/share/nginx/html

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,68 @@
+server {
+    listen       80;
+    server_name  localhost;
+    
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Host $http_host;
+
+    location ~ /react/glossary {
+      return 301 $scheme://$http_host/react/help/glossary.html;
+    }
+
+    location ~ /react/overview {
+      return 301 $scheme://$http_host/react/help/overview.html;
+    }
+
+    location ~ /react/quick-start {
+      return 301 $scheme://$http_host/react/help/quick-start.html;
+    }
+
+    location ~ /react/managing-webhooks {
+      return 301 $scheme://$http_host/react/help/managing-webhooks.html;
+    }
+
+    location ~ /react/settings {
+      return 301 $scheme://$http_host/react/help/settings.html;
+    }
+
+    location ~ /react/user-management {
+      return 301 $scheme://$http_host/react/help/user-management.html;
+    }
+
+    location ~ /react/monitoring-shipments {
+      return 301 $scheme://$http_host/react/help/monitoring-shipments.html;
+    }
+
+    location ~ /react/tracking-pages {
+      return 301 $scheme://$http_host/react/help/tracking-pages.html;
+    }
+
+    location ~ /react/notifications {
+      return 301 $scheme://$http_host/react/help/notifications.html;
+    }
+
+    location ~ /react/registering-shipments {
+      return 301 $scheme://$http_host/react/help/registering-shipments.html;
+    }
+
+    location ~ /react/retrieving-data {
+      return 301 $scheme://$http_host/react/help/retrieving-data.html;
+    }
+
+    location ~ /react/updating-shipments {
+      return 301 $scheme://$http_host/react/help/updating-shipments.html;
+    }
+
+    location ~ /react/error-codes {
+      return 301 $scheme://$http_host/react/help/error-codes.html;
+    }
+
+    location ~ /react/calc-events {
+      return 301 $scheme://$http_host/react/help/calc-events.html;
+    }
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+}

--- a/default.conf
+++ b/default.conf
@@ -5,60 +5,8 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-Host $http_host;
 
-    location ~ /react/glossary {
-      return 301 $scheme://$http_host/react/help/glossary.html;
-    }
-
-    location ~ /react/overview {
-      return 301 $scheme://$http_host/react/help/overview.html;
-    }
-
-    location ~ /react/quick-start {
-      return 301 $scheme://$http_host/react/help/quick-start.html;
-    }
-
-    location ~ /react/managing-webhooks {
-      return 301 $scheme://$http_host/react/help/managing-webhooks.html;
-    }
-
-    location ~ /react/settings {
-      return 301 $scheme://$http_host/react/help/settings.html;
-    }
-
-    location ~ /react/user-management {
-      return 301 $scheme://$http_host/react/help/user-management.html;
-    }
-
-    location ~ /react/monitoring-shipments {
-      return 301 $scheme://$http_host/react/help/monitoring-shipments.html;
-    }
-
-    location ~ /react/tracking-pages {
-      return 301 $scheme://$http_host/react/help/tracking-pages.html;
-    }
-
-    location ~ /react/notifications {
-      return 301 $scheme://$http_host/react/help/notifications.html;
-    }
-
-    location ~ /react/registering-shipments {
-      return 301 $scheme://$http_host/react/help/registering-shipments.html;
-    }
-
-    location ~ /react/retrieving-data {
-      return 301 $scheme://$http_host/react/help/retrieving-data.html;
-    }
-
-    location ~ /react/updating-shipments {
-      return 301 $scheme://$http_host/react/help/updating-shipments.html;
-    }
-
-    location ~ /react/error-codes {
-      return 301 $scheme://$http_host/react/help/error-codes.html;
-    }
-
-    location ~ /react/calc-events {
-      return 301 $scheme://$http_host/react/help/calc-events.html;
+    location ~ \/react\/([A-Za-z0-9\-_]+)$ {
+      return 301 $scheme://$http_host/react/help/$1.html;
     }
 
     location / {


### PR DESCRIPTION
Adding in redirect URLs via nginx config to enable existing URLs to map to their new equivalents - this ensures that existing customers with bookmarks can continue to access documentation.

For example, https://docs.sorted.com/react/glossary will redirect to https://docs.sorted.com/react/help/glossary.html