### PR TITLE
Feature/trailing slash

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -5,7 +5,7 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-Host $http_host;
 
-    location ~ \/react\/([A-Za-z0-9\-_]+)/\?$ {
+    location ~ \/react\/([A-Za-z0-9\-_]+)\/?$ {
       return 301 $scheme://$http_host/react/help/$1.html;
     }
 

--- a/default.conf
+++ b/default.conf
@@ -5,7 +5,7 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-Host $http_host;
 
-    location ~ \/react\/([A-Za-z0-9\-_]+)$ {
+    location ~ \/react\/([A-Za-z0-9\-_]+)/\?$ {
       return 301 $scheme://$http_host/react/help/$1.html;
     }
 


### PR DESCRIPTION
Allows optional trailing slash in redirect from previous REACT pages, e.g. /react/overview and /react/overview/ will both redirect to /react/help/overview.html