### PR TITLE
Updated docfx.json to reference how-to section correctly

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -4,6 +4,8 @@
         "files": [
           "pro/api/help/**.yml",
           "pro/api/help/**.md",
+          "pro/how-to/**.md",
+          "pro/how-to/**.yml",
           "pro/toc.yml",
           "pro/index.md"
         ]
@@ -30,7 +32,7 @@
     "resource": [{
         "files": [
           "pro/images/**",
-          "pro/how-to/**",
+          "pro/how-to/images/**",
           "react/help/images/**",
           "images/**"
         ]


### PR DESCRIPTION
Included the markdown files in docfx.json.

Updated content section to only reference image files.