### PR TITLE
Add missing html to brexit sandbox page

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -9,6 +9,10 @@ server {
       return 301 $scheme://$http_host/react/help/$1.html;
     }
 
+    location ~ \/pro\/how-to\/brexit-sandbox-carrier-changes\/?$ {
+      return 301 $scheme://$http_host/pro/how-to/brexit-sandbox-carrier-changes.html;
+    }
+
     location / {
         root   /usr/share/nginx/html;
         index  index.html index.htm;


### PR DESCRIPTION
Handle missing .html extension from link sent out in email